### PR TITLE
🐛 normalised api base url handling

### DIFF
--- a/cyberchef_api_mcp_server/server.py
+++ b/cyberchef_api_mcp_server/server.py
@@ -36,7 +36,7 @@ def create_api_request(endpoint: str, request_data: dict) -> dict:
     :param request_data: data to send with the POST request
     :return: dict object of response data
     """
-    api_url = f"{cyberchef_api_url}{endpoint}"
+    api_url = f"{cyberchef_api_url.rstrip('/')}/{endpoint.lstrip('/')}"
     request_headers = {
         "Accept": "application/json",
         "Content-Type": "application/json"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,33 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from cyberchef_api_mcp_server import server
 from cyberchef_api_mcp_server.server import (
     bake_recipe, batch_bake_recipe, perform_magic_operation, CyberChefRecipeOperation
 )
+
+
+def test_create_api_request_normalises_base_url(monkeypatch):
+    captured = {}
+
+    class DummyResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"ok": True}
+
+    def fake_post(url, headers, json):
+        captured["url"] = url
+        return DummyResponse()
+
+    monkeypatch.setattr(server, "cyberchef_api_url", "http://127.0.0.1:3000")
+    monkeypatch.setattr(server.httpx, "post", fake_post)
+
+    response = server.create_api_request(endpoint="bake", request_data={"input": "flag", "recipe": []})
+
+    assert response == {"ok": True}
+    assert captured["url"] == "http://127.0.0.1:3000/bake"
 
 
 def test_bake_recipe():


### PR DESCRIPTION
This fixes URL construction in `create_api_request()` when `CYBERCHEF_API_URL` is configured without a trailing slash.

For example, with:

```bash
CYBERCHEF_API_URL=http://127.0.0.1:3000
```

requests were previously built as:

```text
http://127.0.0.1:3000bake
```

This change normalises the base URL before appending endpoint paths, so the request becomes:

```text
http://127.0.0.1:3000/bake
```

Also added a small regression test for this case.
