### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,8 @@ Here is a basic prompt being solved using the MCP server tools:
 🪪 License
 ---
 MIT License
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/slouchd-cyberchef-api-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/slouchd-cyberchef-api-mcp-server).